### PR TITLE
Product-list-item loop in row

### DIFF
--- a/mobile_new/landingpage.html
+++ b/mobile_new/landingpage.html
@@ -19,11 +19,11 @@
 		<div id="products" class="products clearfix">
 			{% import 'mobile_new/product_listing.html' as product_listing %}
 
-			{% for product in products %}
-				<div class="row">
+			<div class="row">
+				{% for product in products %}
 					{{ product_listing.item(product, category, 12) }}
-				</div>
-			{% endfor %}
+				{% endfor %}
+			</div>
 		</div>
 	</div>
 {% endblock %}


### PR DESCRIPTION
Changed products loop to inside row in file landingpage.html in mobile_new.

Before fix, the loop was outside of row, which caused each product in a new line.